### PR TITLE
fun24tv post-launch adjustments

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,8 @@ config :randnews,
   sources: [
     "ua_pravda",
     "ua_nv",
-    "ua_ukrnet"
+    "ua_ukrnet",
+    "ua_fun24tv"
   ]
 
 # It is also possible to import configuration files, relative to this

--- a/lib/loaders/ua/fun24tv.ex
+++ b/lib/loaders/ua/fun24tv.ex
@@ -2,6 +2,7 @@ defmodule Randnews.UA.Fun24tv do
   @behaviour Randnews.SiteModule
 
   @url "https://api.24tv.ua/news/list"
+  @pause_interval 500
   @news_part_count 20
 
   def get(:initial) do
@@ -9,6 +10,8 @@ defmodule Randnews.UA.Fun24tv do
   end
 
   def get({:next, last_end_date}) do
+    # don't overload the API
+    Process.sleep(@pause_interval)
     get_content(last_end_date)
   end
 

--- a/lib/randnews.ex
+++ b/lib/randnews.ex
@@ -8,9 +8,15 @@ defmodule Randnews do
   def dump(file_path, news_count, sites \\ @sites) do
     File.open(file_path, [:write, encoding: :utf8], fn file ->
       stream =
-        Task.async_stream(sites, fn site ->
-          Randnews.Handler.load(site, news_count)
-        end)
+        Task.async_stream(
+          sites,
+          Randnews.Handler,
+          :load,
+          [news_count],
+          # 10 minutes should be enough for a single site
+          timeout: 600_000,
+          ordered: false
+        )
 
       data =
         stream


### PR DESCRIPTION
Changes:
- fun.24.tv added to the list of default sources
- Individual loaders allowed to run for max. 10 minutes before timing out (default value of 5s causes troubles for large requested news counts from fun.24.tv as the default quantity of news per request is 20), ignore ordering of results as it's not important for the output file anyway
- Very basic rate limiting for fun.24.tv (sleep for 500ms between subsequent requests)