### PR TITLE
Add CLI site selection

### DIFF
--- a/lib/mix/tasks/randnews.ex
+++ b/lib/mix/tasks/randnews.ex
@@ -57,7 +57,6 @@ defmodule Mix.Tasks.Randnews do
 
   defp dump(args) do
     Application.ensure_all_started(:hackney)
-    Application.ensure_all_started(:iconv)
 
     if Keyword.has_key?(args, :help) do
       show_help_message(:dump)

--- a/lib/mix/tasks/randnews.ex
+++ b/lib/mix/tasks/randnews.ex
@@ -9,7 +9,9 @@ defmodule Mix.Tasks.Randnews do
         strict: [
           count: :integer,
           help: :boolean,
-          file: :string
+          file: :string,
+          only: :string,
+          skip: :string
         ]
       )
 
@@ -69,7 +71,9 @@ defmodule Mix.Tasks.Randnews do
           args
         )
 
-      Randnews.dump(arguments[:file], arguments[:count])
+      sites = Randnews.Util.SiteSelector.invoke(args)
+
+      Randnews.dump(arguments[:file], arguments[:count], sites)
     end
   end
 

--- a/lib/randnews.ex
+++ b/lib/randnews.ex
@@ -3,9 +3,7 @@ defmodule Randnews do
   Documentation for Randnews.
   """
 
-  @sites Application.compile_env(:randnews, :sources)
-
-  def dump(file_path, news_count, sites \\ @sites) do
+  def dump(file_path, news_count, sites) do
     File.open(file_path, [:write, encoding: :utf8], fn file ->
       stream =
         Task.async_stream(

--- a/lib/util/site_selector.ex
+++ b/lib/util/site_selector.ex
@@ -1,0 +1,36 @@
+defmodule Randnews.Util.SiteSelector do
+  @sites Application.compile_env(:randnews, :sources)
+
+  def invoke(only: only_sites) do
+    site_list =
+      only_sites
+      |> arg_str_to_list()
+
+    @sites
+    |> Enum.filter(fn site ->
+      site_list
+      |> Enum.member?(site)
+    end)
+  end
+
+  def invoke(skip: sites_to_skip) do
+    site_list =
+      sites_to_skip
+      |> arg_str_to_list()
+
+    @sites
+    |> Enum.reject(fn site ->
+      site_list
+      |> Enum.member?(site)
+    end)
+  end
+
+  def invoke(_) do
+    @sites
+  end
+
+  defp arg_str_to_list(arg_str) do
+    arg_str
+    |> String.split(",")
+  end
+end

--- a/test/util/site_selector_test.exs
+++ b/test/util/site_selector_test.exs
@@ -1,0 +1,35 @@
+defmodule Randnews.Util.SiteSelectorTest do
+  use ExUnit.Case
+
+  alias Randnews.Util.SiteSelector
+
+  describe "invoke/1" do
+    test "selects passed sites when given :only option" do
+      assert SiteSelector.invoke(only: "ua_nv") == ["ua_nv"]
+
+      assert SiteSelector.invoke(only: "ua_nv,ua_pravda") |> Enum.sort() ==
+               ["ua_nv", "ua_pravda"] |> Enum.sort()
+
+      assert SiteSelector.invoke(only: "unknown") == []
+    end
+
+    test "ignores passed sites when given :skip option" do
+      refute SiteSelector.invoke(skip: "ua_fun24tv")
+             |> Enum.member?("ua_fun24tv")
+
+      refute SiteSelector.invoke(skip: "ua_fun24tv,ua_nv")
+             |> Enum.member?("ua_fun24tv")
+
+      refute SiteSelector.invoke(skip: "ua_fun24tv,ua_nv")
+             |> Enum.member?("ua_nv")
+    end
+
+    test "returns all sites when :only and :skip are not set" do
+      assert length(SiteSelector.invoke(count: 5)) > 1
+    end
+
+    test "returns all sites when both :only and :skip are passed" do
+      assert length(SiteSelector.invoke(only: "ua_nv", skip: "ua_fun24tv")) > 1
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an ability to specify the sites for news sources download via 2 options:
- `--skip` removes the mentioned site slugs from the global list
- `--only` selects the mentioned site slugs from the global list
In both cases the expected format of the provided data is a comma-separated string.

Note:
The PR also removes a line that is not of use for now (starting `iconv` application, used in the past for converting charsets for a weird news source, no longer supported).